### PR TITLE
Make RabbitMQ user and vhost configurable

### DIFF
--- a/advanced_sunbeam_openstack/charm.py
+++ b/advanced_sunbeam_openstack/charm.py
@@ -67,8 +67,8 @@ class OSBaseOperatorCharm(ops.charm.CharmBase):
                 self,
                 'amqp',
                 self.configure_charm,
-                self.service_name,
-                self.service_name)
+                self.config.get('rabbitmq-user') or self.service_name,
+                self.config.get('rabbitmq-vhost') or 'openstack')
             handlers.append(self.amqp)
         if f'{self.service_name}-db' in self.meta.relations.keys():
             self.db = sunbeam_rhandlers.DBHandler(

--- a/unit_tests/test_core.py
+++ b/unit_tests/test_core.py
@@ -396,7 +396,7 @@ class TestOSBaseOperatorAPICharm(CharmTestCase):
             '/bin/wsgi_admin',
             'hardpassword',
             'true',
-            'rabbit://my-service:rabbit.pass@10.0.0.13:5672/my-service',
+            'rabbit://my-service:rabbit.pass@10.0.0.13:5672/openstack',
             'rabbithost1.local']
         expect_string = '\n' + '\n'.join(expect_entries)
         self.assertEqual(


### PR DESCRIPTION
Most existing charms have configuration options for the RabbitMQ
user and vhost for AMQP relations.  If this information is provided
use it when creating the AMQP relation handler.

Default to the openstack vhost if configuration is not provided
for the vhost.