### PR TITLE
api: patch service -> LoadBalancer

### DIFF
--- a/fetch-libs.sh
+++ b/fetch-libs.sh
@@ -5,3 +5,4 @@ charmcraft fetch-lib charms.sunbeam_mysql_k8s.v0.mysql
 charmcraft fetch-lib charms.sunbeam_keystone_operator.v0.identity_service
 charmcraft fetch-lib charms.sunbeam_rabbitmq_operator.v0.amqp
 charmcraft fetch-lib charms.sunbeam_ovn_central_operator.v0.ovsdb
+charmcraft fetch-lib charms.observability_libs.v0.kubernetes_service_patch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 charmhelpers
 jinja2
 kubernetes
-git+https://github.com/canonical/operator@2875e73e#egg=ops
+ops
 python-keystoneclient
 git+https://opendev.org/openstack/charm-ops-openstack#egg=ops_openstack
 git+https://github.com/openstack/charm-ops-interface-ceph-client#egg=interface_ceph_client
+lightkube
+lightkube-models


### PR DESCRIPTION
For API operator charms, patch the Juju configured service to
a) configure a port and b) switch the type of the service to
LoadBalancer.

This ensures that external access to the API service is configured
in the charm, rather than being a post deployment step.

As the ingress address of the loadbalancer can be discovered via
the K8S API, use this for the Public URL for the service.