### PR TITLE
Rejig template parts

### DIFF
--- a/shared_code/templates/parts/database-connection
+++ b/shared_code/templates/parts/database-connection
@@ -1,0 +1,3 @@
+{% if shared_db.database_host -%}
+connection = {{ shared_db.database_type }}://{{ shared_db.database_user }}:{{ shared_db.database_password }}@{{ shared_db.database_host }}/{{ shared_db.database }}{% if shared_db.database_ssl_ca %}?ssl_ca={{ shared_db.database_ssl_ca }}{% if shared_db.database_ssl_cert %}&ssl_cert={{ shared_db.database_ssl_cert }}&ssl_key={{ shared_db.database_ssl_key }}{% endif %}{% endif %}
+{% endif -%}

--- a/shared_code/templates/parts/identity-connection
+++ b/shared_code/templates/parts/identity-connection
@@ -1,0 +1,10 @@
+{% if identity_service.internal_host -%}
+www_authenticate_uri = {{ identity_service.internal_protocol }}://{{ identity_service.internal_host }}:{{ identity_service.internal_port }}
+auth_url = {{ identity_service.internal_protocol }}://{{ identity_service.internal_host }}:{{ identity_service.internal_port }}
+auth_type = password
+project_domain_name = {{ identity_service.service_domain_name }}
+user_domain_name = {{ identity_service.service_domain_name }}
+project_name = {{ identity_service.service_project_name }}
+username = {{ identity_service.service_user_name }}
+password = {{ identity_service.service_password }}
+{% endif -%}

--- a/shared_code/templates/parts/section-database
+++ b/shared_code/templates/parts/section-database
@@ -1,7 +1,3 @@
 [database]
-{% if shared_db.database_host -%}
-connection = {{ shared_db.database_type }}://{{ shared_db.database_user }}:{{ shared_db.database_password }}@{{ shared_db.database_host }}/{{ shared_db.database }}{% if shared_db.database_ssl_ca %}?ssl_ca={{ shared_db.database_ssl_ca }}{% if shared_db.database_ssl_cert %}&ssl_cert={{ shared_db.database_ssl_cert }}&ssl_key={{ shared_db.database_ssl_key }}{% endif %}{% endif %}
-{% else -%}
-connection = sqlite:////var/lib/cinder/cinder.db
-{% endif -%}
+{% include "parts/database-connection" %}
 connection_recycle_time = 200

--- a/shared_code/templates/parts/section-identity
+++ b/shared_code/templates/parts/section-identity
@@ -1,11 +1,2 @@
 [keystone_authtoken]
-{% if identity_service.internal_host -%}
-www_authenticate_uri = {{ identity_service.internal_protocol }}://{{ identity_service.internal_host }}:{{ identity_service.internal_port }}
-auth_url = {{ identity_service.internal_protocol }}://{{ identity_service.internal_host }}:{{ identity_service.internal_port }}
-auth_type = password
-project_domain_name = {{ identity_service.service_domain_name }}
-user_domain_name = {{ identity_service.service_domain_name }}
-project_name = {{ identity_service.service_project_name }}
-username = {{ identity_service.service_user_name }}
-password = {{ identity_service.service_password }}
-{% endif -%}
+{% include "parts/identity-connection" %}


### PR DESCRIPTION
It is not uncommon for a service to need to reference external
connection strings in configuration files sections other than
the standard [identity], [database] etc. This change makes the
connection strings referencable without the section heading.