### PR TITLE
Peer relation handler not ready if no relation

### DIFF
--- a/advanced_sunbeam_openstack/relation_handlers.py
+++ b/advanced_sunbeam_openstack/relation_handlers.py
@@ -391,7 +391,7 @@ class BasePeerHandler(RelationHandler):
     @property
     def ready(self) -> bool:
         """Whether the handler is complete."""
-        return True
+        return bool(self.interface.peers_rel)
 
     def context(self) -> dict:
         """Return all app data set on the peer relation."""


### PR DESCRIPTION
Mark the peer relation handler as not ready if there is no peer
relation.