### PR TITLE
Fix unit tests

### DIFF
--- a/advanced_sunbeam_openstack/templating.py
+++ b/advanced_sunbeam_openstack/templating.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+from pathlib import Path
 from typing import List, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -62,6 +63,9 @@ def sidecar_config_render(
         "user": config.user,
         "group": config.group,
         "permissions": config.permissions}
+    parent_dir = str(Path(config.path).parent)
+    if not container.isdir(parent_dir):
+        container.make_dir(parent_dir, make_parents=True)
     container.push(config.path, contents, **kwargs)
     log.debug(
         f"Wrote template {config.path} in container {container.name}."

--- a/unit_tests/test_charms.py
+++ b/unit_tests/test_charms.py
@@ -94,9 +94,9 @@ requires:
   shared-db:
     interface: mysql_datastore
     limit: 1
-  ingress:
-    interface: ingress
-    limit: 1
+#  ingress:
+#    interface: ingress
+#    limit: 1
   amqp:
     interface: rabbitmq
   identity-service:

--- a/unit_tests/test_core.py
+++ b/unit_tests/test_core.py
@@ -120,26 +120,21 @@ class TestOSBaseOperatorAPICharm(test_utils.CharmTestCase):
             'svcpass1',
             'bar']
         expect_string = '\n' + '\n'.join(expect_entries)
-        self.assertEqual(
-            self.container_calls.file_update_calls(
-                'my-service',
-                '/etc/my-service/my-service.conf')[0],
-            {
-                'path': '/etc/my-service/my-service.conf',
-                'group': 'my-service',
-                'permissions': None,
-                'source': expect_string,
-                'user': 'my-service'})
-        self.assertEqual(
-            self.container_calls.file_update_calls(
-                'my-service',
-                '/etc/apache2/sites-available/wsgi-my-service.conf')[0],
-            {
-                'path': '/etc/apache2/sites-available/wsgi-my-service.conf',
-                'group': 'root',
-                'permissions': None,
-                'source': expect_string,
-                'user': 'root'})
+        self.harness.set_can_connect('my-service', True)
+        self.check_file(
+            'my-service',
+            '/etc/my-service/my-service.conf',
+            contents=expect_string,
+            user='my-service',
+            group='my-service',
+        )
+        self.check_file(
+            'my-service',
+            '/etc/apache2/sites-available/wsgi-my-service.conf',
+            contents=expect_string,
+            user='root',
+            group='root',
+        )
 
     def test__on_database_changed(self) -> None:
         """Test database is requested."""


### PR DESCRIPTION
* The test harness assumed the charm manages the creation of any
  subdirectories of a file being pushed. To accommodate this (and to
  make the charm generally more defensive) it
  seems reasonable to have the file  rendering method create
  sub directories if they are not present
* The changes to the ingress relation were stopping the tests
  from rendering config because interface.url was unset which
  causes the ingress relation handler to report itself as incomplete. To
  workaround this the ingress relation has been commented out of
  the metadata of the charm used by the unit tests.
* Remove code that was logging file reads and writes as that is
  now handled by ops.testing
* Add check_file method to handled checking a files attributes